### PR TITLE
[FIX] find_outlier_trials()

### DIFF
--- a/meegkit/utils/denoise.py
+++ b/meegkit/utils/denoise.py
@@ -278,7 +278,7 @@ def find_outlier_trials(X, thresh=None, show=True):
         ax2.set_xlim(0, len(idx) + 1)
         plt.show()
 
-    thresh.pop()
+    thresh.pop(0)
     if thresh:
         bads2, _ = find_outlier_trials(X[:, idx], thresh, show)
         idx2 = idx[bads2]


### PR DESCRIPTION
There is a bug `find_outlier_trials` compatible when a list of thresholds is passed.