### PR TITLE
[FIX] Null channels cause dss.dss0 to crash

### DIFF
--- a/meegkit/dss.py
+++ b/meegkit/dss.py
@@ -101,7 +101,7 @@ def dss0(c0, c1, keep1=None, keep2=1e-9):
     W = np.sqrt(1. / eigval0)  # diagonal of whitening matrix
 
     # c1 is projected into whitened PCA space of data channels
-    c2 = (W * eigvec0.squeeze()).T.dot(c1).dot(eigvec0.squeeze()) * W
+    c2 = (W * eigvec0).T.dot(c1).dot(eigvec0) * W
 
     # proj. matrix from whitened data space to a space maximizing bias
     eigvec2, eigval2 = pca(c2, max_comps=keep1, thresh=keep2)

--- a/tests/test_dss.py
+++ b/tests/test_dss.py
@@ -1,19 +1,25 @@
 """Test DSS functions."""
 import matplotlib.pyplot as plt
 import numpy as np
-from meegkit import dss
-from meegkit.utils import demean, fold, rms, tscov, unfold
+import pytest
 from numpy.testing import assert_allclose
 from scipy import signal
 
+from meegkit import dss
+from meegkit.utils import demean, fold, rms, tscov, unfold
 
-def test_dss0():
+
+@pytest.mark.parametrize('n_bad_chans', [0, -1])
+def test_dss0(n_bad_chans):
     """Test dss0.
 
     Find the linear combinations of multichannel data that
     maximize repeatability over trials. Data are time * channel * trials.
 
     Uses dss0().
+
+    `n_bad_chans` set the values of the first corresponding number of channels
+    to zero.
     """
     # create synthetic data
     n_samples = 100 * 3
@@ -29,6 +35,9 @@ def test_dss0():
     s = source * np.random.randn(1, n_chans)  # 300 * 30
     s = s[:, :, np.newaxis]
     s = np.tile(s, (1, 1, 100))
+
+    # set first `n_bad_chans` to zero
+    s[:, :n_bad_chans] = 0.
 
     # noise
     noise = np.dot(
@@ -81,6 +90,5 @@ def test_dss_line():
     plt.show()
 
 if __name__ == '__main__':
-    import pytest
     pytest.main([__file__])
     # test_dss_line()


### PR DESCRIPTION
## Description
When the values of `n_chans - 1` channels are set to zero, `dss.dss0()` returns a` ValueError: expected square matrix` message. This is because the passed input matrix `c2` is one-dimensional (because it has 1 feature only, corresponding to the not-null channel).

Proposed fix is to leave it 2-dimensional by removing `squeeze()`.