### PR TITLE
Bump version + fix sklearn/pyriemann compat

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -19,19 +19,18 @@ import sphinx_bootstrap_theme  # noqa
 import matplotlib
 matplotlib.use('agg')
 
-# import meegkit
-
 curdir = os.path.dirname(__file__)
 sys.path.append(os.path.abspath(os.path.join(curdir, '..')))
 sys.path.append(os.path.abspath(os.path.join(curdir, '..', 'meegkit')))
 
+import meegkit # noqa
 
 # -- Project information -----------------------------------------------------
 
 project = 'MEEGkit'
 copyright = '2020, Nicolas Barascud'
 author = 'Nicolas Barascud'
-version = '0.1'
+version = meegkit.__version__
 
 # -- General configuration ---------------------------------------------------
 

--- a/meegkit/__init__.py
+++ b/meegkit/__init__.py
@@ -1,4 +1,6 @@
 """M/EEG denoising utilities in python."""
+__version__ = '0.1.1'
+
 from . import asr, cca, detrend, dss, sns, star, ress, tspca, utils
 
 __all__ = ['asr', 'cca', 'detrend', 'dss', 'ress', 'sns', 'star', 'tspca',

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,4 +15,4 @@ codespell
 pydocstyle
 tqdm
 statsmodels
-pyriemann
+pyriemann @ git+https://github.com/alexandrebarachant/pyRiemann.git@1ecaa372b7c432f13e82685b2541ee48424a11c9

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,6 @@ setup(
     author='N Barascud',
     author_email='nicolas.barascud@ens.fr',
     license='UNLICENSED',
-    version='0.1',
+    version='0.1.1',
     packages=find_packages(exclude=['doc', 'tests']),
     zip_safe=False)

--- a/tests/test_cca.py
+++ b/tests/test_cca.py
@@ -26,7 +26,7 @@ def test_cca():
     C1 = tscov(np.hstack((X1, Y1)))[0]
 
     # Sklearn CCA
-    cca = CCA(n_components=9, scale=False, max_iter=1e6)
+    cca = CCA(n_components=9, scale=False, max_iter=int(1e6))
     X2, Y2 = cca.fit_transform(x, y)
     # C2 = tscov(np.hstack((X2, Y2)).T)[0]
     # import matplotlib.pyplot as plt


### PR DESCRIPTION
Pyriemann doesn't seem to be maintained anymore, so we have to point to a specific PR that adresses compatibility fixes with scikit-learn>=0.24

cf. https://github.com/alexandrebarachant/pyRiemann/issues/94