### PR TITLE
[FIX] Use linalg.eigh in RESS

### DIFF
--- a/meegkit/asr.py
+++ b/meegkit/asr.py
@@ -363,25 +363,21 @@ def clean_windows(X, sfreq, max_bad_chans=0.2, zthresholds=[-3.5, 5],
 
     # combine the three masks
     remove_mask = np.logical_or.reduce((mask1, mask2, mask3))
-    removed_wins = np.where(remove_mask)
+    removed_wins = np.where(remove_mask)[0]
 
     # reconstruct the samples to remove
     sample_maskidx = []
-    for i in range(len(removed_wins[0])):
+    for i, win in enumerate(removed_wins):
         if i == 0:
-            sample_maskidx = np.arange(
-                offsets[removed_wins[0][i]], offsets[removed_wins[0][i]] + N)
+            sample_maskidx = np.arange(offsets[win], offsets[win] + N)
         else:
-            sample_maskidx = np.vstack((
-                sample_maskidx,
-                np.arange(offsets[removed_wins[0][i]],
-                          offsets[removed_wins[0][i]] + N)
-            ))
+            sample_maskidx = np.r_[(sample_maskidx,
+                                    np.arange(offsets[win], offsets[win] + N))]
 
     # delete the bad chunks from the data
     sample_mask2remove = np.unique(sample_maskidx)
     if sample_mask2remove.size:
-        clean = np.delete(X, sample_mask2remove, 1)
+        clean = np.delete(X, sample_mask2remove, axis=1)
         sample_mask = np.ones((1, ns), dtype=bool)
         sample_mask[0, sample_mask2remove] = False
     else:

--- a/meegkit/dss.py
+++ b/meegkit/dss.py
@@ -35,7 +35,7 @@ def dss1(X, weights=None, keep1=None, keep2=1e-12):
         Power per component (averaged).
 
     """
-    n_samples, n_chans, n_trials = theshapeof(X)
+    n_trials = theshapeof(X)[-1]
 
     # if demean: # remove weighted mean
     #   X = demean(X, weights)

--- a/meegkit/dss.py
+++ b/meegkit/dss.py
@@ -21,7 +21,7 @@ def dss1(X, weights=None, keep1=None, keep2=1e-12):
     keep1: int
         Number of PCs to retain in function:`dss0` (default=all).
     keep2: float
-        Ignore PCs smaller than keep2 in function:`dss0` (default=10^-12).
+        Ignore PCs smaller than keep2 in function:`dss0` (default=1e-12).
 
     Returns
     -------

--- a/tests/test_ress.py
+++ b/tests/test_ress.py
@@ -155,5 +155,5 @@ def test_ress(target, n_trials, peak_width, neig_width, neig_freq, show=False):
 
 if __name__ == '__main__':
     import pytest
-    # pytest.main([__file__])
-    test_ress(20, 16, 1, 1, 1, show=False)
+    pytest.main([__file__])
+    # test_ress(20, 16, 1, 1, 1, show=False)

--- a/tests/test_ress.py
+++ b/tests/test_ress.py
@@ -155,5 +155,5 @@ def test_ress(target, n_trials, peak_width, neig_width, neig_freq, show=False):
 
 if __name__ == '__main__':
     import pytest
-    pytest.main([__file__])
-    # test_ress(12, 20, 1, 1, 1, show=True)
+    # pytest.main([__file__])
+    test_ress(20, 16, 1, 1, 1, show=False)


### PR DESCRIPTION
This replaces `linalg.eig` with `linalg.eigh` in the RESS code (as it provides slightly better results and the symmetry assumption for `eigh` is valid with covariance matrices)

Had to use a tiny bit of shrinkage to the covariance to avoid numerical precision issues in the GED.

Thanks @mikexcohen for the suggestion.

Linking this cool new preprint here as well:
https://arxiv.org/abs/2104.12356