### PR TITLE
[MAINT]  Dont require pybind + test python 3.12

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    groups:
+      actions:
+        patterns:
+          - "*"

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -33,3 +33,4 @@ jobs:
       - name: Run ghp-import
         run: |
           ghp-import -n -p -f doc/_build/html
+        if: github.event_name == 'push' && github.ref == 'refs/heads/master'

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -37,4 +37,4 @@ jobs:
       uses: codecov/codecov-action@v5
       with:
         fail_ci_if_error: false # optional (default = false)
-        token: TBD
+        token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -14,12 +14,12 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install meegkit and dependencies
@@ -34,6 +34,7 @@ jobs:
       run: |
         pytest --cov=./ --cov-report=xml tests/
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v5
       with:
         fail_ci_if_error: false # optional (default = false)
+        token: TBD

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ version = {attr = "meegkit.__version__"}
 dependencies = {file = ["requirements.txt"]}
 
 [tool.setuptools.packages.find]
-exclude = ["tests*", "examples*", "doc*"]
+exclude = ["tests*", "examples*", "doc*", "dist*"]
 
 ##################################
 #          Codespell             #

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ tests = ["pytest", "pytest-cov", "codecov", "codespell", "ruff", "meegkit[extra]
 ##################################
 
 [build-system]
-requires = ["setuptools>=62.0.0", "wheel", "pybind11~=2.10.3"]
+requires = ["setuptools>=62.0.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,8 +17,8 @@ requires-python = ">=3.8"
 [project.urls]
 homepage = "https://nbara.github.io/python-meegkit"
 repository = "https://github.com/nbara/python-meegkit"
-documentation = "https://nbara.github.io/python-meegkit/"
-tracker = "https://github.com/nbara/python-meegkit/issues/"
+documentation = "https://nbara.github.io/python-meegkit"
+tracker = "https://github.com/nbara/python-meegkit/issues"
 
 [project.optional-dependencies]
 extra = ["pymanopt"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ version = {attr = "meegkit.__version__"}
 dependencies = {file = ["requirements.txt"]}
 
 [tool.setuptools.packages.find]
-exclude = ["tests*", "examples*", "doc*", "dist*"]
+exclude = ["tests*", "examples*", "doc*"]
 
 ##################################
 #          Codespell             #

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ readme = {file = "README.md", content-type = "text/markdown"}
 requires-python = ">=3.8"
 
 [project.urls]
+homepage = "https://nbara.github.io/python-meegkit"
 repository = "https://github.com/nbara/python-meegkit"
 documentation = "https://nbara.github.io/python-meegkit/"
 tracker = "https://github.com/nbara/python-meegkit/issues/"


### PR DESCRIPTION
I think a requirement on `pybind11` might have been errantly added in https://github.com/nbara/python-meegkit/pull/68. Perhaps a copy-paste error from adapting another project's pyproject.toml? I don't see it used anywhere but maybe I missed it...

Feel free to close if I'm wrong, this is basically a question-as-PR, I am working on a conda-forge recipe and was surprised to see pybind11 in the host reqs.