### PR TITLE
Update pyriemann mean import

### DIFF
--- a/meegkit/trca.py
+++ b/meegkit/trca.py
@@ -4,7 +4,11 @@
 import numpy as np
 import scipy.linalg as linalg
 from pyriemann.estimation import Covariances
-from pyriemann.utils.mean import mean_covariance
+
+try:
+    from pyriemann.geometry.mean import gmean as mean_covariance
+except ImportError:
+    from pyriemann.utils.mean import mean_covariance
 
 from .utils import theshapeof
 from .utils.trca import bandpass, schaefer_strimmer_cov


### PR DESCRIPTION
## Summary
- Prefer `pyriemann.geometry.mean.gmean` for TRCA mean covariance calls.
- Keep a fallback to `pyriemann.utils.mean.mean_covariance` for older pyriemann versions.

## Why
The old `pyriemann.utils.mean` import emits a deprecation warning in newer pyriemann versions, which fails when deprecations are treated as errors.

## Validation
- `python -W error::DeprecationWarning -c "import meegkit.trca"`
- `python -W error::DeprecationWarning - <<PY ... trca_regul(...) ... PY`
- `python -m pytest tests/test_trca.py -q`
- `python -m ruff check meegkit/trca.py`
