### PR TITLE
[MAINT] Update pyriemann mean import

### DIFF
--- a/meegkit/asr.py
+++ b/meegkit/asr.py
@@ -2,21 +2,13 @@
 import logging
 
 import numpy as np
+import pyriemann
+from pyriemann.geometry.mean import gmean as mean_covariance
 from scipy import linalg, signal
 from statsmodels.robust.scale import mad
 
 from .utils import block_covariance, nonlinear_eigenspace
 from .utils.asr import fit_eeg_distribution, geometric_median, yulewalk, yulewalk_filter
-
-try:
-    import pyriemann
-    try:  # pyriemann >= 0.11 renamed mean_covariance to gmean
-        from pyriemann.geometry.mean import gmean as mean_covariance
-    except ImportError:  # older pyriemann
-        from pyriemann.utils.mean import mean_covariance
-except ImportError:
-    pyriemann = None
-    mean_covariance = None
 
 
 class ASR:
@@ -105,10 +97,6 @@ class ASR:
                  win_overlap=0.66, max_dropout_fraction=0.1,
                  min_clean_fraction=0.25, method="euclid", memory=None,
                  estimator="scm", **kwargs):
-
-        if pyriemann is None and method == "riemann":
-            logging.warning("Need pyriemann to use riemannian ASR flavor.")
-            method = "euclid"
 
         self.cutoff = cutoff
         self.blocksize = blocksize

--- a/meegkit/asr.py
+++ b/meegkit/asr.py
@@ -10,8 +10,13 @@ from .utils.asr import fit_eeg_distribution, geometric_median, yulewalk, yulewal
 
 try:
     import pyriemann
+    try:  # pyriemann >= 0.11 renamed mean_covariance to gmean
+        from pyriemann.geometry.mean import gmean as mean_covariance
+    except ImportError:  # older pyriemann
+        from pyriemann.utils.mean import mean_covariance
 except ImportError:
     pyriemann = None
+    mean_covariance = None
 
 
 class ASR:
@@ -506,7 +511,7 @@ def asr_calibrate(X, sfreq, cutoff=5, blocksize=100, win_len=0.5,
         Uavg = geometric_median(U.reshape((-1, nc * nc)))
         Uavg = Uavg.reshape((nc, nc))
     else:  # method == 'riemann'
-        Uavg = pyriemann.utils.mean.mean_covariance(U, metric="riemann")
+        Uavg = mean_covariance(U, metric="riemann")
 
     # get the mixing matrix M
     M = linalg.sqrtm(np.real(Uavg))
@@ -584,7 +589,7 @@ def asr_process(X, X_filt, state, cov=None, detrend=False, method="riemann",
     cov = cov.squeeze()
     if cov.ndim == 3:
         if method == "riemann":
-            cov = pyriemann.utils.mean.mean_covariance(
+            cov = mean_covariance(
                 cov, metric="riemann", sample_weight=sample_weight)
         else:
             cov = geometric_median(cov.reshape((-1, nc * nc)))

--- a/meegkit/trca.py
+++ b/meegkit/trca.py
@@ -4,11 +4,7 @@
 import numpy as np
 import scipy.linalg as linalg
 from pyriemann.estimation import Covariances
-
-try:  # pyriemann >= 0.11 renamed mean_covariance to gmean
-    from pyriemann.geometry.mean import gmean as mean_covariance
-except ImportError:  # older pyriemann
-    from pyriemann.utils.mean import mean_covariance
+from pyriemann.geometry.mean import gmean as mean_covariance
 
 from .utils import theshapeof
 from .utils.trca import bandpass, schaefer_strimmer_cov

--- a/meegkit/trca.py
+++ b/meegkit/trca.py
@@ -1,10 +1,22 @@
 """Task-Related Component Analysis."""
 # Authors: Giuseppe Ferraro <giuseppe.ferraro@isae-supaero.fr>
 #          Ludovic Darmet <ludovic.darmet@isae-supaero.fr>
+import warnings
+
 import numpy as np
 import scipy.linalg as linalg
 from pyriemann.estimation import Covariances
-from pyriemann.utils.mean import mean_covariance
+
+try:
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "error",
+            message="pyriemann\\.utils\\.mean is deprecated.*",
+            category=DeprecationWarning,
+        )
+        from pyriemann.utils.mean import mean_covariance
+except (DeprecationWarning, ImportError):
+    from pyriemann.geometry.mean import gmean as mean_covariance
 
 from .utils import theshapeof
 from .utils.trca import bandpass, schaefer_strimmer_cov

--- a/meegkit/trca.py
+++ b/meegkit/trca.py
@@ -1,22 +1,14 @@
 """Task-Related Component Analysis."""
 # Authors: Giuseppe Ferraro <giuseppe.ferraro@isae-supaero.fr>
 #          Ludovic Darmet <ludovic.darmet@isae-supaero.fr>
-import warnings
-
 import numpy as np
 import scipy.linalg as linalg
 from pyriemann.estimation import Covariances
 
-try:
-    with warnings.catch_warnings():
-        warnings.filterwarnings(
-            "error",
-            message="pyriemann\\.utils\\.mean is deprecated.*",
-            category=DeprecationWarning,
-        )
-        from pyriemann.utils.mean import mean_covariance
-except (DeprecationWarning, ImportError):
+try:  # pyriemann >= 0.11 renamed mean_covariance to gmean
     from pyriemann.geometry.mean import gmean as mean_covariance
+except ImportError:  # older pyriemann
+    from pyriemann.utils.mean import mean_covariance
 
 from .utils import theshapeof
 from .utils.trca import bandpass, schaefer_strimmer_cov

--- a/meegkit/utils/covariances.py
+++ b/meegkit/utils/covariances.py
@@ -33,7 +33,10 @@ def block_covariance(data, window=128, overlap=0.5, padding=True, estimator="cov
         Block covariance.
 
     """
-    from pyriemann.utils.covariance import check_function, cov_est_functions
+    try:  # pyriemann >= 0.11 moved covariance utils to geometry.covariance
+        from pyriemann.geometry.covariance import check_function, cov_est_functions
+    except ImportError:  # older pyriemann
+        from pyriemann.utils.covariance import check_function, cov_est_functions
 
     assert 0 <= overlap < 1, "overlap must be < 1"
     est = check_function(estimator, cov_est_functions)

--- a/meegkit/utils/covariances.py
+++ b/meegkit/utils/covariances.py
@@ -1,5 +1,6 @@
 """Covariance calculation."""
 import numpy as np
+from pyriemann.geometry.covariance import covariances
 from scipy import linalg
 
 from .base import mldivide
@@ -33,14 +34,8 @@ def block_covariance(data, window=128, overlap=0.5, padding=True, estimator="cov
         Block covariance.
 
     """
-    try:  # pyriemann >= 0.11 moved covariance utils to geometry.covariance
-        from pyriemann.geometry.covariance import check_function, cov_est_functions
-    except ImportError:  # older pyriemann
-        from pyriemann.utils.covariance import check_function, cov_est_functions
-
     assert 0 <= overlap < 1, "overlap must be < 1"
-    est = check_function(estimator, cov_est_functions)
-    cov = []
+    blocks = []
     n_chans, n_samples = data.shape
     if padding:  # pad data with zeros
         pad = np.zeros((n_chans, int(window / 2)))
@@ -49,10 +44,10 @@ def block_covariance(data, window=128, overlap=0.5, padding=True, estimator="cov
     jump = int(window * overlap)
     ix = 0
     while (ix + window < n_samples):
-        cov.append(est(data[:, ix:ix + window]))
+        blocks.append(data[:, ix:ix + window])
         ix = ix + jump
 
-    return np.array(cov)
+    return covariances(np.array(blocks), estimator=estimator)
 
 
 def cov_lags(X, Y, shifts=None):

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ pandas
 joblib
 tqdm
 statsmodels
-pyriemann>=0.7
+pyriemann>=0.12

--- a/tests/test_pyriemann_imports.py
+++ b/tests/test_pyriemann_imports.py
@@ -1,0 +1,54 @@
+"""pyriemann API compatibility tests."""
+from pathlib import Path
+
+import numpy as np
+
+from meegkit.utils.covariances import block_covariance
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _version_tuple(version):
+    return tuple(int(part) for part in version.split("."))
+
+
+def test_pyriemann_lower_bound_uses_geometry_api():
+    """Ensure the supported pyriemann range has the geometry namespace."""
+    requirement = next(
+        line
+        for line in (ROOT / "requirements.txt").read_text().splitlines()
+        if line.startswith("pyriemann")
+    )
+
+    _, lower_bound = requirement.split(">=")
+
+    assert _version_tuple(lower_bound) >= (0, 12)
+
+
+def test_pyriemann_imports_use_modern_public_api():
+    """Keep deprecated pyriemann utils imports out of meegkit."""
+    source_files = [
+        ROOT / "meegkit" / "asr.py",
+        ROOT / "meegkit" / "trca.py",
+        ROOT / "meegkit" / "utils" / "covariances.py",
+    ]
+    source = "\n".join(path.read_text() for path in source_files)
+
+    assert "pyriemann.utils.mean" not in source
+    assert "pyriemann.utils.covariance" not in source
+    assert "check_function" not in source
+    assert "cov_est_functions" not in source
+
+
+def test_block_covariance_uses_pyriemann_covariances():
+    """Compare block covariance with pyriemann's vectorized covariance helper."""
+    from pyriemann.geometry.covariance import covariances
+
+    data = 0.1 + 0.01 * (1 + np.arange(24, dtype=float).reshape(3, 8))
+    expected_blocks = np.array(
+        [data[:, start:start + 4] for start in range(0, 4, 2)]
+    )
+
+    actual = block_covariance(data, window=4, overlap=0.5, padding=False)
+
+    np.testing.assert_allclose(actual, covariances(expected_blocks, estimator="cov"))


### PR DESCRIPTION
## Summary
- Try the legacy pyriemann mean import first for older releases.
- Fall back to `pyriemann.geometry.mean.gmean` when the legacy module emits the deprecation warning or is unavailable.

## Why
Newer pyriemann versions deprecate `pyriemann.utils.mean`, which can fail when deprecations are treated as errors.

## Validation
- `python -W error::DeprecationWarning -c "import meegkit.trca"`
- `python -W error::DeprecationWarning - <<PY ... trca_regul(...) ... PY`
- `python -m pytest tests/test_trca.py -q`
- `python -m ruff check meegkit/trca.py`
