### PR TITLE
[ENH] ASR: vectorise fit_eeg_distribution grid search

### DIFF
--- a/meegkit/utils/asr.py
+++ b/meegkit/utils/asr.py
@@ -103,9 +103,7 @@ def fit_eeg_distribution(X, min_clean_fraction=0.25, max_dropout_fraction=0.1,
                      step_sizes[0])
     cols = np.round(n * cols).astype(int)
     rows = np.arange(0, int(np.round(n * max_width)))
-    newX = np.zeros((len(rows), len(cols)))
-    for i, c in enumerate(range(len(rows))):
-        newX[i] = X[c + cols]
+    newX = X[rows[:, None] + cols[None, :]]
 
     # subtract baseline value for each interval
     X1 = newX[0, :]
@@ -123,12 +121,13 @@ def fit_eeg_distribution(X, min_clean_fraction=0.25, max_dropout_fraction=0.1,
         cols = nbins / newX[mcurr]
         H = newX[:m] * cols
 
-        hist_all = []
-        for ih in range(len(cols)):
-            histcurr = np.histogram(H[:, ih], bins=np.arange(0, nbins + 1))
-            hist_all.append(histcurr[0])
-        hist_all = np.array(hist_all, dtype=int).T
-        hist_all = np.vstack((hist_all, np.zeros(len(cols), dtype=int)))
+        # per-column histogram over integer bins [0, 1, ..., nbins]
+        ncol = H.shape[1]
+        binidx = np.minimum(H.astype(int), nbins - 1)
+        flat = binidx + np.arange(ncol) * nbins
+        hist_all = np.bincount(
+            flat.ravel(), minlength=nbins * ncol).reshape(ncol, nbins).T
+        hist_all = np.vstack((hist_all, np.zeros(ncol, dtype=int)))
         logq = np.log(hist_all + 0.01)
 
         # for each shape value...


### PR DESCRIPTION
## Summary
`fit_eeg_distribution` dominates ASR calibration: it runs once per channel (and
per rotated component), and its grid search builds a per-column histogram at
every grid step. Two hot spots are vectorised.

1. The quantile-interval matrix `newX` was filled row by row in a Python loop of
   fancy-index gathers; this becomes a single gather
   `X[rows[:, None] + cols[None, :]]`.
2. Inside the grid loop the histogram of each column was computed with a
   separate `np.histogram` call. The bins are the fixed integer edges
   `[0, 1, ..., nbins]` and the column values lie in `[0, nbins]`, so a single
   `np.bincount` reproduces every column at once. `H >= 0`, so `astype(int)` is
   a floor and matches np.histogram's half-open bins; clipping the top index to
   `nbins - 1` reproduces its inclusive final edge.

## Impact
`fit_eeg_distribution` (fine-grid regime) ~23 → ~13 ms/call (~1.8×).

## Correctness
- Bit-identical parameter estimates on the test data.
- The vectorised histogram matches `np.histogram` exactly over 3000 random
  matrices whose values land on bin edges.
