### PR TITLE
[FIX] ASR: return an estimate when geometric_median does not converge

### DIFF
--- a/meegkit/utils/asr.py
+++ b/meegkit/utils/asr.py
@@ -387,8 +387,9 @@ def geometric_median(X, tol=1e-5, max_iter=500):
         y = y1
         i += 1
     else:
-        print(f"Geometric median could converge in {i} iterations "
+        print(f"Geometric median could not converge in {i} iterations "
               f"with a tolerance of {tol}")
+        return y
 
 
 def polystab(a):


### PR DESCRIPTION
## Summary
When the Vardi–Zhang iteration in `geometric_median` reached `max_iter` without
meeting the tolerance, the `while ... else` branch only printed a message and
the function fell through to an implicit `return None`, which breaks callers
(`asr_calibrate` / `asr_process` reshape the result). Return the last iterate
`y` instead, which is the best estimate available.

The message wording is also fixed ("could converge" → "could not converge").

## Correctness
- The converged path is unchanged.
- On non-convergence the function now returns a correctly-shaped array instead
  of `None` (verified with a forced single-iteration run).
