### PR TITLE
[MAINT] Update minimum Python to 3.10

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
 
     steps:
     - uses: actions/checkout@v5

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 # `MEEGkit`
 
-Denoising tools for M/EEG processing in Python 3.8+.
+Denoising tools for M/EEG processing in Python 3.10+.
 
 ![meegkit-ERP](https://user-images.githubusercontent.com/10333715/176754293-eaa35071-94f8-40dd-a487-9f8103c92571.png)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ license = {text = "BSD (3-clause)"}
 dynamic = ["version", "dependencies"]
 description = "M/EEG denoising in Python"
 readme = {file = "README.md", content-type = "text/markdown"}
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 
 [project.urls]
 homepage = "https://nbara.github.io/python-meegkit"


### PR DESCRIPTION
## Summary
- raise the package minimum supported Python version from 3.9 to 3.10
- drop Python 3.9 from the GitHub Actions test matrix
- update the README support statement to match the packaging metadata

## Testing
- ./.venv/bin/python -m pytest tests/test_cov.py -q