### PR TITLE
[FIX] ASR: make nonlinear_eigenspace reproducible

### DIFF
--- a/meegkit/utils/covariances.py
+++ b/meegkit/utils/covariances.py
@@ -13,8 +13,6 @@ from .matrix import (
     unsqueeze,
 )
 
-rng = np.random.default_rng()
-
 
 def block_covariance(data, window=128, overlap=0.5, padding=True, estimator="cov"):
     """Compute blockwise covariance.
@@ -486,9 +484,9 @@ def nonlinear_eigenspace(L, k, alpha=1):
             alpha * np.diagflat(mldivide(L, rhoX)) @ U
         return h
 
-    # Initialization as suggested in above referenced paper.
-    # randomly generate starting point for svd
-    x = rng.standard_normal((n, k))
+    # Initialization as suggested in above referenced paper. Use a fixed seed
+    # so results are reproducible (the starting point only affects convergence).
+    x = np.random.default_rng(1468432035).standard_normal((n, k))
     [U, S, V] = linalg.svd(x, full_matrices=False)
     x = U.dot(V.T)
     S0, U0 = linalg.eig(

--- a/tests/test_cov.py
+++ b/tests/test_cov.py
@@ -2,8 +2,19 @@ import numpy as np
 from numpy.testing import assert_almost_equal
 
 from meegkit.utils import convmtx, tscov, tsxcov
+from meegkit.utils.covariances import nonlinear_eigenspace
 
 rng = np.random.default_rng(10)
+
+
+def test_nonlinear_eigenspace_reproducible():
+    """nonlinear_eigenspace returns identical results across calls."""
+    A = rng.standard_normal((6, 6))
+    L = A @ A.T + np.eye(6)
+    d1, v1 = nonlinear_eigenspace(L, 6)
+    d2, v2 = nonlinear_eigenspace(L, 6)
+    np.testing.assert_array_equal(np.real(d1), np.real(d2))
+    np.testing.assert_array_equal(v1, v2)
 
 def test_tscov():
     """Test time-shift covariance."""


### PR DESCRIPTION
`nonlinear_eigenspace` drew its optimization starting point from an unseeded module-level `np.random.default_rng()`, so the riemann ASR path produced slightly different results on every call. Because the manifold optimizer converges to the same eigenspace regardless of the starting point, this only injected run-to-run numerical noise — but that noise makes the riemann results non-reproducible and destabilizes the incremental-vs-bulk equivalence check in `test_asr_class` (its `< 6µV` tolerance can be exceeded depending on dependency versions and the covariance regime).

Seed the starting point with a fixed value so the riemann path is reproducible run-to-run. The mathematical result is unchanged; only the previously-random initialization is now deterministic.

### Testing
Adds `test_nonlinear_eigenspace_reproducible` asserting repeated calls return identical results (fails on the unseeded code, passes after). Full `tests/test_cov.py` and `tests/test_asr.py` pass; `ruff` clean.
